### PR TITLE
chore(devShell): swap `minikube` for `kind`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,9 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            kind
             kubectl
             kubernetes-helm
+            minikube
             nodejs_22
             nodePackages.cdk8s-cli
             poetry


### PR DESCRIPTION
Swaps in `minikube` for a more fleshed out developer experience (e.g., dashboards, easy-to-use service DNS, etc.)