### PR TITLE
chore(devShell): remove `nodePackages.cdk8s-cli`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,6 @@
             kubectl
             kubernetes-helm
             nodejs_22
-            nodePackages.cdk8s-cli
             poetry
             postgresql
             python312


### PR DESCRIPTION
Removes `nodePackages.cdk8s-cli` from `devShell` as explicit flake dependency to encourage inclusion of the CLI in `package.json`s