### PR TITLE
fix(dbt): utilize `custom_schema_name` & `target.user` in schema gen

### DIFF
--- a/melt-dbt/macros/generate_schema_name.sql
+++ b/melt-dbt/macros/generate_schema_name.sql
@@ -1,6 +1,7 @@
 {% macro generate_schema_name(custom_schema_name, node) -%}
-    {%- if target.name == "production" -%} {{ target.schema }}
-    {%- elif custom_schema_name is none -%} {{ target.schema }}
-    {%- else -%} {{ target.schema }}_{{ custom_schema_name | trim }}
+    {%- if target.name == "production" and custom_schema_name is not none -%}
+        {{ custom_schema_name }}
+    {% elif custom_schema_name is none %} {{ target.schema }}_{{ target.user }}
+    {%- else -%} {{ target.schema }}_{{ target.user }}_{{ custom_schema_name | trim }}
     {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
Correct `generate_schema_name` to generate schema names like so:

|   `target.name` |   `target.user` |   `custom_schema_name` |            result            |
| --------------- | --------------- | ---------------------- | ---------------------------- |
| `production`    | `johndoe`       | `shop`                 |  `shop`                      |
| `development`   | `johndoe`       | `shop`                 |  `development_shop_johndoe`  |
| `development`   | `johndoe`       | `none`                 |  `development_shop`          |